### PR TITLE
IFCJ-109 added mobilepay as paymentMethodType to make it configurable…

### DIFF
--- a/src/Plugin/Commerce/PaymentGateway/ReepayCheckout.php
+++ b/src/Plugin/Commerce/PaymentGateway/ReepayCheckout.php
@@ -35,6 +35,7 @@ use Symfony\Component\HttpFoundation\Request;
  *     "offsite-payment" =
  *   "Drupal\commerce_payment_reepay\PluginForm\OffsiteRedirect\ReepayCheckoutForm",
  *   },
+ *   payment_method_types = {"credit_card", "mobilepay"},
  *   credit_card_types = {
  *     "amex", "dinersclub", "discover", "jcb", "maestro", "mastercard",
  *   "visa",

--- a/src/Plugin/Commerce/PaymentMethodType/Mobilepay.php
+++ b/src/Plugin/Commerce/PaymentMethodType/Mobilepay.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\commerce_payment_reepay\Plugin\Commerce\PaymentMethodType;
+
+use \Drupal\entity\BundleFieldDefinition;
+use Drupal\commerce_payment\Entity\PaymentMethodInterface;
+use Drupal\commerce_payment\Plugin\Commerce\PaymentMethodType\PaymentMethodTypeBase;
+
+/**
+ * Provides a Mobilepay payment type.
+ *
+ * @CommercePaymentMethodType(
+ *   id = "mobilepay",
+ *   label = @Translation("Mobilepay"),
+ *   create_label = @Translation("Mobilepay"),
+ * )
+ */
+class Mobilepay extends PaymentMethodTypeBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildLabel(PaymentMethodInterface $payment_method) {
+    return $this->t('Mobilepay');
+  }
+
+}


### PR DESCRIPTION
… on the payment gateway what sub methods is supported, only implemented in the custom graphql endpoint for now.